### PR TITLE
Fix duplicate names issues

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,3 +1,5 @@
+
+
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
@@ -75,3 +77,15 @@ jobs:
         node-version: 12.x
     - run: npm ci
     - run: npm run lint
+
+  sanity-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm ci
+    - run: npm run sanity-check

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,15 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-
+        {
+            "name": "Launch Sanity",
+            "program": "${workspaceFolder}/test/sanity-check.js",
+            "request": "launch",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node"
+        },
         {
             "name": "Launch Lookup",
             "program": "${workspaceFolder}/index.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "test": "mocha",
     "test2": "cross-env ENUF_INCLUDE_SKIP_TEST=true mocha -g \"getEnums|complete enuf config\"",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "sanity-check": "node test/sanity-check.js"
   },
   "repository": {
     "type": "git",

--- a/test/sanity-check.js
+++ b/test/sanity-check.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+const fs = require("fs")
+const path = require("path")
+const _ = require("lodash")
+
+// This script does some sanity checking on the supplied data set ./data/_allSEts.json
+
+// 1. Ensure no duplicate member names within a set. If there are this indicates an upstream issue
+//    that needs to be resolved.
+
+const parentDir = path.dirname(__dirname)
+const dataFileName = path.join(parentDir, "data", "_allSets.json")
+const allEnums = JSON.parse(fs.readFileSync(dataFileName, { encoding: "utf8" }))
+
+
+// Finds duplicate member names in a set.
+function findDuplicates(set) {
+    const memberNames = _.chain(set.members)
+        .map(member => member.name)
+        .sort()
+        .value()
+
+    const adjacentNames = _.zip(memberNames, _.slice(memberNames, 1))
+
+    const duplicates = _.chain(adjacentNames)
+        .filter(([name1, name2]) => name1 === name2)
+        .map(([name1]) => name1)
+        .value()
+
+    if (duplicates.length > 0) {
+        return duplicates
+    }
+
+}
+
+var noDuplicates = true
+
+_.forEach(allEnums, enumSet => {
+    const duplicates = findDuplicates(enumSet)
+    if (duplicates) {
+        noDuplicates = false
+        console.log(`Duplicates for '${enumSet.name}: ${JSON.stringify(duplicates, null, 2)}`)
+    }
+})
+
+if (!noDuplicates) {
+    // A non zero exit code indicates error.
+    process.exit(1)
+}


### PR DESCRIPTION
The symbolic names generated from the ca_dictionary
can sometimes be duplicates after under-going camel casing.

This has been addressed in ca_translations scripts but wasn't
addressed in this repo until now.